### PR TITLE
Sync scene Wit object with the Understanding Viewer in play mode

### DIFF
--- a/Scripts/Editor/BaseWitWindow.cs
+++ b/Scripts/Editor/BaseWitWindow.cs
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+using System;
 using com.facebook.witai.data;
 using UnityEditor;
 using UnityEngine;
@@ -30,6 +31,11 @@ namespace com.facebook.witai
         protected virtual void OnEnable()
         {
             RefreshConfigList();
+        }
+
+        protected virtual void OnDisable()
+        {
+
         }
 
         protected virtual void OnProjectChange()


### PR DESCRIPTION
Sets up the Understanding Viewer to be able to send and receive wit commands directly via the current scene's Wit object. This gives feedback for play mode testing and allows text activations to be sent from the viewer.