### PR TITLE
Introducing request-level entities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ sysinfo.txt
 *.apk
 *.unitypackage
 
+# Mac OS files
+.DS_Store
+
 # Crashlytics generated file
 crashlytics-build.properties
 

--- a/Scripts/Editor/Utility/WitUnderstandingViewer.cs
+++ b/Scripts/Editor/Utility/WitUnderstandingViewer.cs
@@ -238,7 +238,7 @@ namespace com.facebook.witai.utility
             else
             {
                 submitStart = System.DateTime.Now;
-                var request = witConfiguration.MessageRequest(utterance);
+                var request = witConfiguration.MessageRequest(utterance, new WitRequestOptions());
                 request.onResponse = (r) => ShowResponse(r.ResponseData);
                 request.Request();
                 loading = true;

--- a/Scripts/Runtime/Configuration/WitJsonEntityList.cs
+++ b/Scripts/Runtime/Configuration/WitJsonEntityList.cs
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+using UnityEngine;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Net;
+using com.facebook.witai.data;
+using com.facebook.witai.events;
+using com.facebook.witai.interfaces;
+using com.facebook.witai.lib;
+using UnityEngine.Serialization;
+
+
+namespace com.facebook.witai
+{
+	public class WitJsonEntityList : IEntityListProvider
+    {
+        public string  myJson = "{}";
+        public WitJsonEntityList(string json)
+        {
+            myJson = json;
+        }
+        public string ToJSON() 
+          {
+            return myJson;
+          }
+    }
+}

--- a/Scripts/Runtime/Configuration/WitJsonEntityList.cs.meta
+++ b/Scripts/Runtime/Configuration/WitJsonEntityList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 586b59b3b1f254da18dcf9a311c1d9db
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Configuration/WitRequestOptions.cs
+++ b/Scripts/Runtime/Configuration/WitRequestOptions.cs
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+using UnityEngine;
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Net;
+using com.facebook.witai.data;
+using com.facebook.witai.events;
+using com.facebook.witai.interfaces;
+using com.facebook.witai.lib;
+using UnityEngine.Serialization;
+
+namespace com.facebook.witai
+{
+
+	public class WitRequestOptions
+    {
+        public IEntityListProvider  entityListProvider;
+    }
+}

--- a/Scripts/Runtime/Configuration/WitRequestOptions.cs.meta
+++ b/Scripts/Runtime/Configuration/WitRequestOptions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a6834fd3c55fb41a1885302e6043f5d6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Configuration/WitSimpleEntityList.cs
+++ b/Scripts/Runtime/Configuration/WitSimpleEntityList.cs
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+using UnityEngine;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Net;
+using com.facebook.witai.data;
+using com.facebook.witai.events;
+using com.facebook.witai.interfaces;
+using com.facebook.witai.lib;
+using UnityEngine.Serialization;
+
+
+namespace com.facebook.witai
+{
+
+	public class WitSimpleEntityList : IEntityListProvider
+    {
+        public List<string> keywords;
+        public string entity;
+
+        public WitSimpleEntityList(string entityIdentifier, List<string> words)
+        {
+            entity = entityIdentifier;
+            keywords = words;
+        }
+
+        public string ToJSON() 
+          {
+            List<string> keywordJSON = new List<string>();
+            foreach (string keyword in keywords)
+            {
+              keywordJSON.Add("{\"keyword\":\"" +keyword+ "\",\"synonyms\":[\""+keyword+"\"]}");
+            }
+            return "{\"" +entity+ "\":["+ string.Join(",", keywordJSON) + "]}";
+          }
+    }
+}

--- a/Scripts/Runtime/Configuration/WitSimpleEntityList.cs
+++ b/Scripts/Runtime/Configuration/WitSimpleEntityList.cs
@@ -19,8 +19,8 @@ using UnityEngine.Serialization;
 
 
 namespace com.facebook.witai
-{
-
+{   
+    [Serializable]
 	public class WitSimpleEntityList : IEntityListProvider
     {
         public List<string> keywords;
@@ -34,12 +34,7 @@ namespace com.facebook.witai
 
         public string ToJSON() 
           {
-            List<string> keywordJSON = new List<string>();
-            foreach (string keyword in keywords)
-            {
-              keywordJSON.Add("{\"keyword\":\"" +keyword+ "\",\"synonyms\":[\""+keyword+"\"]}");
-            }
-            return "{\"" +entity+ "\":["+ string.Join(",", keywordJSON) + "]}";
+            return JsonUtility.ToJson(this);
           }
     }
 }

--- a/Scripts/Runtime/Configuration/WitSimpleEntityList.cs
+++ b/Scripts/Runtime/Configuration/WitSimpleEntityList.cs
@@ -19,8 +19,7 @@ using UnityEngine.Serialization;
 
 
 namespace com.facebook.witai
-{   
-    [Serializable]
+{
 	public class WitSimpleEntityList : IEntityListProvider
     {
         public List<string> keywords;
@@ -34,7 +33,12 @@ namespace com.facebook.witai
 
         public string ToJSON() 
           {
-            return JsonUtility.ToJson(this);
+            List<string> keywordJSON = new List<string>();
+            foreach (string keyword in keywords)
+            {
+                keywordJSON.Add("{\"keyword\":\"" + keyword + "\",\"synonyms\":[\""+ keyword +"\"]}");
+            }
+            return "{\"" +entity+ "\":["+ string.Join(",", keywordJSON) + "]}";
           }
     }
 }

--- a/Scripts/Runtime/Configuration/WitSimpleEntityList.cs.meta
+++ b/Scripts/Runtime/Configuration/WitSimpleEntityList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 826639b0e3b5340839c1b9eac62da741
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Interfaces/IEntityListProvider.cs
+++ b/Scripts/Runtime/Interfaces/IEntityListProvider.cs
@@ -1,0 +1,20 @@
+﻿/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+using com.facebook.witai.events;
+using UnityEngine.Events;
+
+namespace com.facebook.witai.interfaces
+{
+    public interface IEntityListProvider
+    {
+        /// <summary>
+        /// Used to get Dynamic Entities
+        /// </summary>
+        string ToJSON();
+    }
+}

--- a/Scripts/Runtime/Interfaces/IEntityListProvider.cs
+++ b/Scripts/Runtime/Interfaces/IEntityListProvider.cs
@@ -12,9 +12,11 @@ namespace com.facebook.witai.interfaces
 {
     public interface IEntityListProvider
     {
+
         /// <summary>
         /// Used to get Dynamic Entities
         /// </summary>
         string ToJSON();
+
     }
 }

--- a/Scripts/Runtime/Interfaces/IEntityListProvider.cs.meta
+++ b/Scripts/Runtime/Interfaces/IEntityListProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6e74b7bf16c8415a8214cdb660784d2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/VoiceService.cs
+++ b/Scripts/Runtime/VoiceService.cs
@@ -35,6 +35,12 @@ namespace com.facebook.witai
         /// Activate the microphone and send data for NLU processing.
         /// </summary>
         public abstract void Activate();
+        
+        /// <summary>
+        /// Activate the microphone and send data for NLU processing.
+        /// </summary>
+        /// <param name="requestOptions"></param>
+        public abstract void Activate(WitRequestOptions requestOptions);
 
         public abstract void ActivateImmediately();
 
@@ -48,6 +54,13 @@ namespace com.facebook.witai
         /// </summary>
         /// <param name="transcription"></param>
         public abstract void Activate(string transcription);
+        
+        /// <summary>
+        /// Send text data for NLU processing with custom request options.
+        /// </summary>
+        /// <param name="transcription"></param>
+        /// <param name="requestOptions"></param>
+        public abstract void Activate(string transcription, WitRequestOptions requestOptions);
     }
 
     public interface IVoiceService
@@ -70,6 +83,12 @@ namespace com.facebook.witai
         /// </summary>
         void Activate();
 
+        /// <summary>
+        /// Activate the microphone and send data for NLU processing with custom request options.
+        /// </summary>
+        /// <param name="requestOptions"></param>
+        void Activate(WitRequestOptions requestOptions);
+
         void ActivateImmediately();
 
         /// <summary>
@@ -82,5 +101,13 @@ namespace com.facebook.witai
         /// </summary>
         /// <param name="transcription"></param>
         void Activate(string transcription);
+        
+        /// <summary>
+        /// Send text data for NLU processing with custom request options.
+        /// </summary>
+        /// <param name="transcription"></param>
+        /// <param name="requestOptions"></param>
+        void Activate(string transcription, WitRequestOptions requestOptions);
+
     }
 }

--- a/Scripts/Runtime/VoiceService.cs
+++ b/Scripts/Runtime/VoiceService.cs
@@ -43,6 +43,7 @@ namespace com.facebook.witai
         public abstract void Activate(WitRequestOptions requestOptions);
 
         public abstract void ActivateImmediately();
+        public abstract void ActivateImmediately(WitRequestOptions requestOptions);
 
         /// <summary>
         /// Stop listening and submit the collected microphone data for processing.
@@ -90,6 +91,7 @@ namespace com.facebook.witai
         void Activate(WitRequestOptions requestOptions);
 
         void ActivateImmediately();
+        void ActivateImmediately(WitRequestOptions requestOptions);
 
         /// <summary>
         /// Stop listening and submit the collected microphone data for processing.

--- a/Scripts/Runtime/Wit.cs
+++ b/Scripts/Runtime/Wit.cs
@@ -26,6 +26,7 @@ namespace com.facebook.witai
 
         private float activationTime;
         private IAudioInputSource micInput;
+        private WitRequestOptions currentRequestOptions;
         private float lastMinVolumeLevelTime;
         private WitRequest activeRequest;
 
@@ -220,7 +221,7 @@ namespace com.facebook.witai
             {
                 events.OnMinimumWakeThresholdHit?.Invoke();
                 isSoundWakeActive = false;
-                ActivateImmediately();
+                ActivateImmediately(currentRequestOptions);
             }
         }
 
@@ -292,6 +293,13 @@ namespace com.facebook.witai
         /// </summary>
         public override void Activate()
         {
+            Activate(new WitRequestOptions());
+        }
+            /// <summary>
+        /// Activate the microphone and send data to Wit for NLU processing.
+        /// </summary>
+        public void Activate(WitRequestOptions requestOptions)
+        {
             if (!micInput.IsRecording && ShouldSendMicData)
             {
                 if (null == micDataBuffer && runtimeConfiguration.micBufferLengthInSeconds > 0)
@@ -319,10 +327,15 @@ namespace com.facebook.witai
                 isActive = true;
 
                 lastMinVolumeLevelTime = float.PositiveInfinity;
+                currentRequestOptions = requestOptions;
             }
         }
 
         public override void ActivateImmediately()
+        {
+            ActivateImmediately(new WitRequestOptions());
+        }
+        public void ActivateImmediately(WitRequestOptions requestOptions)
         {
             // Make sure we aren't checking activation time until
             // the mic starts recording. If we're already recording for a live
@@ -335,7 +348,7 @@ namespace com.facebook.witai
 
             if (ShouldSendMicData)
             {
-                activeRequest = RuntimeConfiguration.witConfiguration.SpeechRequest();
+                activeRequest = RuntimeConfiguration.witConfiguration.SpeechRequest(requestOptions);
                 activeRequest.audioEncoding = micInput.AudioEncoding;
                 activeRequest.onPartialTranscription =
                     s => updateQueue.Enqueue(() => OnPartialTranscription(s));
@@ -447,17 +460,34 @@ namespace com.facebook.witai
         /// Send text data to Wit.ai for NLU processing
         /// </summary>
         /// <param name="transcription"></param>
-        public override void Activate(string transcription)
+        public override void Activate(string transcription, WitRequestOptions requestOptions)
         {
             if (Active) return;
 
-            SendTranscription(transcription);
+            SendTranscription(transcription, requestOptions);
+        }
+
+         /// <summary>
+        /// Send text data to Wit.ai for NLU processing
+        /// </summary>
+        /// <param name="transcription"></param>
+        public void Activate(string transcription)
+        {
+            Activate(transcription, new WitRequestOptions());
         }
 
         private void SendTranscription(string transcription)
         {
+            SendTranscription(transcription, new WitRequestOptions());
+        }
+
+        private void SendTranscription(string transcription, WitRequestOptions requestOptions)
+        {
+            if(requestOptions == null){
+                requestOptions = new WitRequestOptions();
+            }
             isActive = true;
-            activeRequest = RuntimeConfiguration.witConfiguration.MessageRequest(transcription);
+            activeRequest = RuntimeConfiguration.witConfiguration.MessageRequest(transcription, requestOptions);
             activeRequest.onResponse = QueueResult;
             events.OnRequestCreated?.Invoke(activeRequest);
             activeRequest.Request();

--- a/Scripts/Runtime/Wit.cs
+++ b/Scripts/Runtime/Wit.cs
@@ -336,7 +336,7 @@ namespace com.facebook.witai
         {
             ActivateImmediately(new WitRequestOptions());
         }
-        public void ActivateImmediately(WitRequestOptions requestOptions)
+        public override void ActivateImmediately(WitRequestOptions requestOptions)
         {
             // Make sure we aren't checking activation time until
             // the mic starts recording. If we're already recording for a live

--- a/Scripts/Runtime/Wit.cs
+++ b/Scripts/Runtime/Wit.cs
@@ -295,10 +295,11 @@ namespace com.facebook.witai
         {
             Activate(new WitRequestOptions());
         }
-            /// <summary>
+        
+        /// <summary>
         /// Activate the microphone and send data to Wit for NLU processing.
         /// </summary>
-        public void Activate(WitRequestOptions requestOptions)
+        public override void Activate(WitRequestOptions requestOptions)
         {
             if (!micInput.IsRecording && ShouldSendMicData)
             {
@@ -460,6 +461,7 @@ namespace com.facebook.witai
         /// Send text data to Wit.ai for NLU processing
         /// </summary>
         /// <param name="transcription"></param>
+        /// <param name="requestOptions"></param>
         public override void Activate(string transcription, WitRequestOptions requestOptions)
         {
             if (Active) return;
@@ -471,7 +473,7 @@ namespace com.facebook.witai
         /// Send text data to Wit.ai for NLU processing
         /// </summary>
         /// <param name="transcription"></param>
-        public void Activate(string transcription)
+        public override void Activate(string transcription)
         {
             Activate(transcription, new WitRequestOptions());
         }

--- a/Scripts/Runtime/WitRequestFactory.cs
+++ b/Scripts/Runtime/WitRequestFactory.cs
@@ -4,10 +4,12 @@
  * This source code is licensed under the license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
+using UnityEngine;
 using System.Text;
 using com.facebook.witai.data;
 using com.facebook.witai.interfaces;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace com.facebook.witai
 {
@@ -24,9 +26,14 @@ namespace com.facebook.witai
         /// <param name="config"></param>
         /// <param name="query">Text string to process with the NLU</param>
         /// <returns></returns>
-        public static WitRequest MessageRequest(this WitConfiguration config, string query)
+        public static WitRequest MessageRequest(this WitConfiguration config, string query, WitRequestOptions requestOptions)
         {
-            return new WitRequest(config, "message", QueryParam("q", query));
+            List<WitRequest.QueryParam> queryParams = new List<WitRequest.QueryParam>();
+            queryParams.Add(QueryParam("q", query));
+            if(requestOptions.entityListProvider != null){
+                queryParams.Add(QueryParam("dynamic_entities", requestOptions.entityListProvider.ToJSON()));
+            }
+            return new WitRequest(config, "message", queryParams.ToArray());
         }
 
         /// <summary>
@@ -35,9 +42,14 @@ namespace com.facebook.witai
         /// <param name="config"></param>
         /// <param name="maxBestIntents"></param>
         /// <returns></returns>
-        public static WitRequest SpeechRequest(this WitConfiguration config, int maxBestIntents = 1)
+        public static WitRequest SpeechRequest(this WitConfiguration config, WitRequestOptions requestOptions, int maxBestIntents = 1)
         {
-            return new WitRequest(config, "speech", QueryParam("n", maxBestIntents.ToString()));
+            List<WitRequest.QueryParam> queryParams = new List<WitRequest.QueryParam>();
+            queryParams.Add(QueryParam("n", maxBestIntents.ToString()));
+            if(requestOptions.entityListProvider != null){
+                queryParams.Add(QueryParam("dynamic_entities", requestOptions.entityListProvider.ToJSON()));
+            }
+            return new WitRequest(config, "speech", queryParams.ToArray());
         }
 
         /// <summary>

--- a/Scripts/Runtime/WitRequestFactory.cs
+++ b/Scripts/Runtime/WitRequestFactory.cs
@@ -31,7 +31,7 @@ namespace com.facebook.witai
             List<WitRequest.QueryParam> queryParams = new List<WitRequest.QueryParam>();
             queryParams.Add(QueryParam("q", query));
             if(requestOptions.entityListProvider != null){
-                queryParams.Add(QueryParam("dynamic_entities", requestOptions.entityListProvider.ToJSON()));
+                queryParams.Add(QueryParam("entities", requestOptions.entityListProvider.ToJSON()));
             }
             return new WitRequest(config, "message", queryParams.ToArray());
         }
@@ -47,7 +47,7 @@ namespace com.facebook.witai
             List<WitRequest.QueryParam> queryParams = new List<WitRequest.QueryParam>();
             queryParams.Add(QueryParam("n", maxBestIntents.ToString()));
             if(requestOptions.entityListProvider != null){
-                queryParams.Add(QueryParam("dynamic_entities", requestOptions.entityListProvider.ToJSON()));
+                queryParams.Add(QueryParam("entities", requestOptions.entityListProvider.ToJSON()));
             }
             return new WitRequest(config, "speech", queryParams.ToArray());
         }


### PR DESCRIPTION
Example usage:
```
      WitRequestOptions options = new WitRequestOptions();
      options.entityListProvider = new WitSimpleEntityList("colors", new List<string> {"red","aqua","forest"});
      wit.Activate("make the sphere aqua", options); 
```
Also works for speech activation.