### PR TITLE
WitConfigurationUtility.GetLoadedConfigurations() fix

### DIFF
--- a/Scripts/Editor/Data/Configuration/WitConfigurationUtility.cs
+++ b/Scripts/Editor/Data/Configuration/WitConfigurationUtility.cs
@@ -118,6 +118,11 @@ namespace Meta.WitAi.Data.Configuration
             for (int sceneIndex = 0; sceneIndex < SceneManager.sceneCount; sceneIndex++)
             {
                 Scene scene = SceneManager.GetSceneAt(sceneIndex);
+                if (!scene.isLoaded)
+                {
+                    continue;
+                }
+
                 foreach (var rootGameObject in scene.GetRootGameObjects())
                 {
                     IWitConfigurationProvider[] providers = rootGameObject.GetComponentsInChildren<IWitConfigurationProvider>(true);


### PR DESCRIPTION
Added check if the scene is loaded for this case:
If you add two or more scenes to the "Hierarchy" window and unload one of them, then every time the scripts are reloaded, an error will occur:
``Exception thrown while invoking [DidReloadScripts] method 'Meta.WitAi.Windows.WitConfigurationEditor:OnScriptsReloaded ()' : ArgumentException: The scene is not loaded.
UnityEngine.SceneManagement.Scene.GetRootGameObjects (System.Collections.Generic.List`1[T] rootGameObjects) (at /Users/bokken/build/output/unity/unity/Runtime/Export/SceneManager/Scene.cs:100)
UnityEngine.SceneManagement.Scene.GetRootGameObjects () (at /Users/bokken/build/output/unity/unity/Runtime/Export/SceneManager/Scene.cs:84)
Meta.WitAi.Data.Configuration.WitConfigurationUtility.GetLoadedConfigurations () (at /Users/bymedion/Documents/GitRepos/wit-unity/Scripts/Editor/Data/Configuration/WitConfigurationUtility.cs:121)
Meta.WitAi.Windows.WitConfigurationEditor.OnScriptsReloaded () (at /Users/bymedion/Documents/GitRepos/wit-unity/Scripts/Editor/Data/Configuration/WitConfigurationEditor.cs:506)``